### PR TITLE
[+] Use extra data in FlatList to handle state sent by props

### DIFF
--- a/src/components/GridList/index.js
+++ b/src/components/GridList/index.js
@@ -159,6 +159,7 @@ export default class GridList extends PureComponent {
         showsVerticalScrollIndicator={false}
         {...props}
         data={this._data}
+        extraData={this._data}
         renderItem={this.renderItem}
       />
     );


### PR DESCRIPTION
Hello @gusgard,

I try to display pictures fetched with an API, but currently I can't display my pictures with grid-list because the FlatList doesn't have a extraData props so it can't handle state sent by props.



